### PR TITLE
sshdriver: include port in the ControlSocket name

### DIFF
--- a/labgrid/driver/sshdriver.py
+++ b/labgrid/driver/sshdriver.py
@@ -62,7 +62,7 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
 
         self.tmpdir = tempfile.mkdtemp(prefix='labgrid-ssh-tmp-')
         control = os.path.join(
-            self.tmpdir, 'control-{}'.format(self.networkservice.address)
+            self.tmpdir, 'control-{}-{}'.format(self.networkservice.address, self.networkservice.port)
         )
         # use sshpass if we have a password
         args = ["sshpass", "-e"] if self.networkservice.password else []


### PR DESCRIPTION
Previously only the address was included in the ControlSocket name,
which leads to the SSHDriver killing the first connection by overwriting
the ControlSocket on the second connection. Include the port name in the
ControlSocket name to allow multiple connections to the same host on
different ports.

Fixes https://github.com/labgrid-project/labgrid/issues/658

Signed-off-by: Rouven Czerwinski <r.czerwinski@pengutronix.de>

<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modifiy one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Provide a short summary for the CHANGES.rst file
--->
- [ ] CHANGES.rst has been updated
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [ ] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
